### PR TITLE
Changed node-zip from dev to peer dependency as was failing to install

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt": "~0.4.2",
-    "node-zip": "~1.0.1"
+    "grunt": "~0.4.2"
   },
   "peerDependencies": {
-    "grunt": "~0.4.2"
+    "grunt": "~0.4.2",
+    "node-zip": "~1.0.1"
   },
   "keywords": [
     "gruntplugin", "maven", "war", "maven-war-plugin"


### PR DESCRIPTION
I noticed that when you first install grunt-war none of the dependencies are installed with it, this caused it to fail when it runs due to node-zip not being present.

Hopefully this will ensure it runs.
