### PR TITLE
use grunt dest instead of custom rewrite

### DIFF
--- a/tasks/war.js
+++ b/tasks/war.js
@@ -53,10 +53,9 @@ module.exports = function (grunt) {
             try {
                 var file_name = each.src[0];
                 if (!grunt.file.isDir(file_name)) {
-                    var src_folder_length = 1 + Math.max(indexOfRegEx(file_name,(/\//)),indexOfRegEx(file_name,(/\\/)));
 
                     war(zip, options, {
-                        filename: (file_name).substring(src_folder_length),
+                        filename: each.dest,
                         data: fs.readFileSync(file_name, 'binary')
                     });
                 }


### PR DESCRIPTION
This allows more flexible output paths inside the war bundle using Grunt's built in dest rewrite. It is perhaps a breaking change however if you were depending on the existing output w/o a 'dest' configuration..
