### PR TITLE
fixed a second WEB-INF/web.xml being added on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
+#### 0.4.5
+* Fixed a second WEB-INF/web.xml being added on windows.
+
 #### 0.4.4
 * Bug fix that prevented old wars from being deleted
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-war",
   "description": "Pure JS implementation for generating a WAR file.",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "homepage": "https://github.com/MorrisLLC/grunt-war",
   "author": {
     "name": "Robert Morris",

--- a/tasks/war.js
+++ b/tasks/war.js
@@ -208,7 +208,7 @@ module.exports = function (grunt) {
     };
 
     var containsWebXML = function (files) {
-        var testWebXML = 'WEB-INF' + path.sep + 'web.xml';
+        var testWebXML = 'WEB-INF/web.xml';
         return files.some(function (each) {
                 return !grunt.file.isDir(each.src[0]) && testWebXML.localeCompare(each.dest) == 0;
             }


### PR DESCRIPTION
The files that are passed to containsWebXML() also use "/" as path separator on windows. path.sep returns "\", though, so the comparison for web.xml failed, resulting in two web.xml files being added to the zip (if there already is one in WEB-INF/web.xml).